### PR TITLE
fix(@deip/attributes-module):fixed header label at attributes list table

### DIFF
--- a/packages/casimir/modules/attributes/lib/components/AttributesList/AttributesList.vue
+++ b/packages/casimir/modules/attributes/lib/components/AttributesList/AttributesList.vue
@@ -220,14 +220,17 @@
             value: 'shortTitle'
           },
           {
-            align: 'start',
+            text: 'Markers',
+            align: 'end',
             sortable: false,
             value: 'markers'
           },
           {
+            text: 'Actions',
             align: 'end',
             sortable: false,
-            value: 'actions'
+            value: 'actions',
+            class: 'pr-6'
           }
         ];
       }


### PR DESCRIPTION
fixed: header label at attributes list table on the admin panel attributes page

* added label for Markers and Actions

![attrTitle](https://user-images.githubusercontent.com/59886821/151315824-d8b4a38a-aae4-4802-8766-4b6999b8ede7.png)

