### PR TITLE
fix(@deip/auth-module):fixed autofill sign in form

### DIFF
--- a/packages/casimir/modules/auth/lib/components/AuthSignIn.vue
+++ b/packages/casimir/modules/auth/lib/components/AuthSignIn.vue
@@ -18,6 +18,7 @@
               <v-text-field
                 ref="usernameFieldRef"
                 v-model="formModel.username"
+                name="username"
                 :label="usernameLabel"
                 :error-messages="errors"
                 v-bind="fieldsProps"
@@ -32,6 +33,7 @@
               <vex-password-input
                 ref="passwordFieldRef"
                 v-model="formModel.password"
+                name="password"
                 :label="passwordLabel"
                 :error-messages="errors"
                 v-bind="fieldsProps"


### PR DESCRIPTION
* now the login button will work as soon as the browser fills in the form fields

![sighnIn](https://user-images.githubusercontent.com/59886821/151986540-180eca60-5c9e-4d5b-ac09-5aa974b01ccf.png)

