### PR TITLE
fix(@deip/vuetify-extended):fixed vex-date-time-input initial behavior

### DIFF
--- a/packages/casimir/plugins/VuetifyExtended/lib/components/VexInput/VexDateTimeInput/VexDateTimeInput.vue
+++ b/packages/casimir/plugins/VuetifyExtended/lib/components/VexInput/VexDateTimeInput/VexDateTimeInput.vue
@@ -56,7 +56,7 @@
       return {
         internalValue: {
           date: '',
-          time: ''
+          time: '00:00'
         }
       };
     },


### PR DESCRIPTION
* fixed initial behavior of vex-date-time-input
* now the validator won't show an error right after the date is selected because the time will be set 

**Before**
![dateTime](https://user-images.githubusercontent.com/59886821/153025452-4cfb7c06-dae7-4278-944f-33237c2b7bfb.png)

**After**
![dateTimeNow](https://user-images.githubusercontent.com/59886821/153026808-7572c74c-c60b-421c-98f2-cb140be024fe.png)


